### PR TITLE
Use official (master) tag for registration job

### DIFF
--- a/bundles/litmos-connector-0.1.0/chart/litmos-connector/templates/job.yaml
+++ b/bundles/litmos-connector-0.1.0/chart/litmos-connector/templates/job.yaml
@@ -18,7 +18,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: {{ .Values.apiRegistrationJobName }}
-        image: "eu.gcr.io/kyma-project/incubator/api-registration-job:qualtricsv1"
+        image: "eu.gcr.io/kyma-project/incubator/api-registration-job:master"
         imagePullPolicy: Always
         envFrom:
         - configMapRef:

--- a/bundles/qualtrics-connector-0.1.0/chart/qualtrics-connector/templates/registration-job.yaml
+++ b/bundles/qualtrics-connector-0.1.0/chart/qualtrics-connector/templates/registration-job.yaml
@@ -18,7 +18,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: {{ .Values.apiRegistrationJobName }}
-        image: "eu.gcr.io/kyma-project/incubator/api-registration-job:qualtricsv1"
+        image: "eu.gcr.io/kyma-project/incubator/api-registration-job:master"
         imagePullPolicy: Always
         envFrom:
         - configMapRef:

--- a/bundles/qualtrics-connector-0.1.0/meta.yaml
+++ b/bundles/qualtrics-connector-0.1.0/meta.yaml
@@ -9,6 +9,5 @@ labels:
 providerDisplayName: SAP
 longDescription: "Integrates SAP Qualtrics in preview mode by registering its REST APIs in an existing Application and enables consuming the APIs from a lambda or microservice. This connector also creates subscriptions for events in SAP Qualtrics and provides a gateway that allows events to be published to Kyma. It is not recommended for production use."
 documentationURL: https://storage.googleapis.com/faros-stage-base-xf-bundles/installation/qualtrics.html
-imageURL: https://storage.googleapis.com/faros-stage-base-xf-bundles/icons/qualtrics-connector.svg
 bindable: false
 provisionOnlyOnce: true


### PR DESCRIPTION
- use master (official) tag for Docker image
- Remove imageURL for Qualtrics Connector